### PR TITLE
Removing a bad Xbootclasspath hack, which breaks narwhal.

### DIFF
--- a/engines/rhino/bin/narwhal-rhino
+++ b/engines/rhino/bin/narwhal-rhino
@@ -24,10 +24,6 @@ BOOTCLASSPATH=$NARWHAL_ENGINE_HOME/jars/js.jar
 JAVA_OPTS=""
 isOpenJDK=`java -version 2>&1 | grep -i "OpenJDK" | wc -l`
 
-if [ $isOpenJDK -gt 0 ]; then
-    JAVA_OPTS="-Xbootclasspath:/usr/lib/jvm/java-6-openjdk/jre/lib/rt.jar"
-fi
-
 if [ -n "$NARWHAL_CLASSPATH" ]; then
     CLASSPATH=$NARWHAL_CLASSPATH:$CLASSPATH
 fi


### PR DESCRIPTION
This was a bad idea when it came about, but it now actively breaks Java on any platform which doesn't have rt.jar in /usr/lib/jvm/java-6-openjdk/jre/lib. Which soon will be all of them (with JDK 7), but it has been for a long time the case on Fedora/RHEL.
